### PR TITLE
ajuste de nova rota para buscar atrações dada coordenada, recebe agor…

### DIFF
--- a/Sources/Networking/URLBuilders/AttractionUrl.swift
+++ b/Sources/Networking/URLBuilders/AttractionUrl.swift
@@ -18,12 +18,19 @@ public enum AttractionUrlBuilder {
     static private var baseURL: String { BASE_URL }
     
     // TODO: Mudar types para um enum, podendo ser o do google, ou um personalizado... q respeite as caracteristicas do google (?)
-    case atCoordinate(latitude: Double, longitude: Double/*, types: [String]?*/)
+    case atCoordinate(latitude: Double, longitude: Double, cityName: String?, countryName: String?/*, types: [String]?*/)
     
     public var request: URLRequest? {
         switch self {
-        case .atCoordinate(let latitude, let longitude/*, let types*/):
+        case .atCoordinate(let latitude, let longitude, let city, let country/*, let types*/):
             var urlString = "\(Self.baseURL)/attraction/coordinates?latitude=\(latitude)&longitude=\(longitude)"
+            if let city {
+                urlString += "&city=\(city)"
+            }
+            
+            if let country {
+                urlString += "&country=\(country)"
+            }
 //            if let types {
 //                for type in types {
 //                    urlString += "&types[]=\(type)"


### PR DESCRIPTION
ADD:
- Dada a mudança no server para realizar a busca pelas fotos do local em uma segunda etapa, reduzindo chamadas de google, foi necessário reformular a chamada da rota, informando o nome da cidade e do país permitindo que o bot saiba como buscar
- OBS: Caso não seja informado o nome da cidade e o nome do país, o bot não fará a busca pelas imagens
- rever a regra
…a como opcionais a informação do nome da cidade e o nome do país, quando informado permitem que o bot faça a busca pela imagem